### PR TITLE
Add command profiles:exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,14 +174,14 @@ _See code: [src/commands/profiles/delete.ts](https://github.com/teamdigitale/io-
 
 ## `io-ops profiles:exist`
 
-Check if, for the given fiscal codes, there are relative profiles or not. It outputs the given csv with a new last column containing true if a profile exists.
+Returns the input CSV with a new column that is true if a profile for that fiscal code exists.
 
 ```
 USAGE
   $ io-ops profiles:exist
 
 OPTIONS
-  -i, --input=input        (required) Input file (CSV, with the CF as first column)
+  -i, --input=input        Input file (CSV, with the CF as first column) - defaults to stdin
   -p, --parallel=parallel  [default: 1] Number of parallel workers to run
 ```
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ USAGE
 - [`io-ops messages:list FISCALCODE`](#io-ops-messageslist-fiscalcode)
 - [`io-ops profiles:list`](#io-ops-profileslist)
 - [`io-ops profiles:delete FISCALCODE`](#io-ops-profilesdelete)
-- [`io-ops profiles:exist FISCALCODE`](#io-ops-profilesexist)
+- [`io-ops profiles:exist`](#io-ops-profilesexist)
 
 ## `io-ops hello [FILE]`
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ _See code: [src/commands/profiles/delete.ts](https://github.com/teamdigitale/io-
 
 ## `io-ops profiles:exist`
 
-Check if, for the given fiscal codes, there are active profiles or not. Return the given csv with a new last column contains profile exist or not.
+Check if, for the given fiscal codes, there are relative profiles or not. It outputs the given csv with a new last column containing true if a profile exists.
 
 ```
 USAGE

--- a/README.md
+++ b/README.md
@@ -171,4 +171,19 @@ OPTIONS
 
 _See code: [src/commands/profiles/delete.ts](https://github.com/teamdigitale/io-ops/blob/v0.0.4/src/commands/profiles/delete.ts)_
 
+## `io-ops profiles:exist`
+
+Check if, for the given fiscal codes, there are active profiles or not. Return the given csv with a new last column contains profile exist or not.
+
+```
+USAGE
+  $ io-ops profiles:exist
+
+OPTIONS
+  -i, --input=input        (required) Input file (CSV, with the CF as first column)
+  -p, --parallel=parallel  [default: 1] Number of parallel workers to run
+```
+
+_See code: [src/commands/profiles/exist.ts](https://github.com/teamdigitale/io-ops/blob/v0.0.4/src/commands/profiles/exist.ts)_
+
 <!-- commandsstop -->

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ USAGE
 - [`io-ops messages:list FISCALCODE`](#io-ops-messageslist-fiscalcode)
 - [`io-ops profiles:list`](#io-ops-profileslist)
 - [`io-ops profiles:delete FISCALCODE`](#io-ops-profilesdelete)
+- [`io-ops profiles:exist FISCALCODE`](#io-ops-profilesexist)
 
 ## `io-ops hello [FILE]`
 

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "azure-storage": "^2.10.3",
     "cli-ux": "^5.2.1",
     "csv-parse": "^4.4.1",
+    "csv-stringify": "^5.3.0",
     "execa": "sindresorhus/execa#0d39fdffeb053215a56a631db8d2cf32ea119a95",
     "io-ts": "^1.8.6",
     "italia-ts-commons": "^5.1.3",

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -49,23 +49,12 @@ export default class ProfilesExist extends Command {
       const container = database.container("profiles");
 
       const hasProfile = async (fiscalCode: string): Promise<boolean> => {
-        const documentId = `${fiscalCode}-${"0".repeat(16)}`;
-        const response = container.items.query(
-          {
-            parameters: [
-              {
-                name: "@documentId",
-                value: documentId
-              }
-            ],
-            query: "SELECT VALUE COUNT(1) FROM c WHERE c.id = @documentId"
-          },
-          {
-            enableCrossPartitionQuery: true
-          }
-        );
-        const { result: item } = await response.nextItem();
-        return item !== undefined && item === 1;
+        const response = container.items.query({
+          parameters: [{ name: "@fiscalCode", value: fiscalCode }],
+          query: `SELECT VALUE COUNT(1) FROM c WHERE c.fiscalCode = @fiscalCode AND c.version = 0`
+        });
+        const { result: item } = await response.current();
+        return item === 1;
       };
 
       const castBoolean = (value: boolean, _: csvStringify.CastingContext) =>

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -9,7 +9,7 @@ import { getCosmosConnection } from "../../utils/azure";
 
 export default class ProfilesExist extends Command {
   public static description =
-    "Check if, for the given fiscal codes, there are active profiles or not. Return the given csv with a new last column contains profile exist or not.";
+    "Check if, for the given fiscal codes, there are relative profiles or not. Ouput the given csv with a new last column contains true if a profile exists";
 
   public static flags = {
     input: flags.string({

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -9,7 +9,7 @@ import { getCosmosConnection } from "../../utils/azure";
 
 export default class ProfilesExist extends Command {
   public static description =
-    "Check if, for the given fiscal codes, there are relative profiles or not. Ouput the given csv with a new last column contains true if a profile exists";
+    "Check if, for the given fiscal codes, there are relative profiles or not. It outputs the given csv with a new last column contains true if a profile exists";
 
   public static flags = {
     input: flags.string({

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -98,7 +98,7 @@ export default class ProfilesExist extends Command {
             ];
             return [
               ...formattedRecord,
-              allProfilesCf.has(fiscalCode.trim().toUpperCase()) ? true : false
+              allProfilesCf.has(fiscalCode.trim().toUpperCase())
             ];
           })()
             .then(_ => cb(null, _))

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -63,15 +63,22 @@ export default class ProfilesExist extends Command {
       // create a set of fiscalCodes
       const allProfilesCf = new Set<string>(result.map(r => r.fiscalCode));
 
+      const castBoolean = (value: boolean, _: csvStringify.CastingContext) =>
+        value ? "true" : "false";
       // return the output (csv string) if no error occurred
-      const transformer = csvStringify((error, output) => {
-        if (error) {
-          return `some error occured while parsing this line ${error.message}`;
-        } else if (output === undefined) {
-          return "row cannot be parsed";
+      const transformer = csvStringify(
+        { cast: { boolean: castBoolean } },
+        (error, output) => {
+          if (error) {
+            return `some error occured while parsing this line ${
+              error.message
+            }`;
+          } else if (output === undefined) {
+            return "row cannot be parsed";
+          }
+          return output;
         }
-        return output;
-      });
+      );
 
       /**
        * append to record an entry with the result of check: active if
@@ -91,9 +98,7 @@ export default class ProfilesExist extends Command {
             ];
             return [
               ...formattedRecord,
-              allProfilesCf.has(fiscalCode.trim().toUpperCase())
-                ? "active"
-                : "not active"
+              allProfilesCf.has(fiscalCode.trim().toUpperCase()) ? true : false
             ];
           })()
             .then(_ => cb(null, _))

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -9,7 +9,7 @@ import { getCosmosConnection } from "../../utils/azure";
 
 export default class ProfilesExist extends Command {
   public static description =
-    "Check if, for the given fiscal codes, there are relative profiles or not. It outputs the given csv with a new last column contains true if a profile exists";
+    "Check if, for the given fiscal codes, there are relative profiles or not. It outputs the given csv with a new last column containing true if a profile exists";
 
   public static flags = {
     input: flags.string({

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -1,0 +1,114 @@
+import * as cosmos from "@azure/cosmos";
+import { Command, flags } from "@oclif/command";
+import cli from "cli-ux";
+import * as parse from "csv-parse";
+import * as csvStringify from "csv-stringify";
+import * as fs from "fs";
+import * as transform from "stream-transform";
+import { getCosmosConnection } from "../../utils/azure";
+
+export default class ProfilesExist extends Command {
+  public static description =
+    "Check if, for the given fiscal codes, there are active profiles or not. Return the given csv with a new last column contains profile exist or not.";
+
+  public static flags = {
+    input: flags.string({
+      char: "i",
+      description: "Input file (CSV, with the CF as first column)",
+      required: true
+    }),
+    parallel: flags.integer({
+      char: "p",
+      default: 1,
+      description: "Number of parallel workers to run"
+    })
+  };
+
+  public async run(): Promise<void> {
+    const { flags: parsedFlags } = this.parse(ProfilesExist);
+
+    const inputStream = fs.createReadStream(parsedFlags.input);
+
+    const parser = parse({
+      trim: true,
+      skip_empty_lines: true
+    });
+
+    try {
+      cli.action.start("Retrieving cosmosdb credentials");
+      const { endpoint, key } = await getCosmosConnection(
+        "agid-rg-test",
+        "agid-cosmosdb-test"
+      );
+      cli.action.stop();
+
+      cli.action.start("Querying profiles...");
+      const client = new cosmos.CosmosClient({ endpoint, auth: { key } });
+      const database = client.database("agid-documentdb-test");
+      const container = database.container("profiles");
+
+      // retrieve all fiscalCodes from database
+      const response = container.items.query(
+        "SELECT c.fiscalCode FROM c WHERE c.version = 0",
+        {
+          enableCrossPartitionQuery: true
+        }
+      );
+      const result = (await response.toArray()).result;
+      cli.action.stop();
+      if (result === undefined) {
+        this.error("No result");
+        return;
+      }
+      // create a set of fiscalCodes
+      const allProfilesCf = new Set<string>(result.map(r => r.fiscalCode));
+
+      // return the output (csv string) if no error occurred
+      const transformer = csvStringify((error, output) => {
+        if (error) {
+          return `some error occured while parsing this line ${error.message}`;
+        } else if (output === undefined) {
+          return "row cannot be parsed";
+        }
+        return output;
+      });
+
+      /**
+       * append to record an entry with the result of check: active if
+       * the fiscalCode is present into the database. As side operation it
+       * return the fiscalCode in upperCase format
+       */
+      const checker = transform(
+        {
+          parallel: parsedFlags.parallel
+        },
+        (record, cb) =>
+          (async () => {
+            const fiscalCode = record[0] as string;
+            const formattedRecord: ReadonlyArray<string> = [
+              fiscalCode.toUpperCase(),
+              ...record.slice(1)
+            ];
+            return [
+              ...formattedRecord,
+              allProfilesCf.has(fiscalCode.trim().toUpperCase())
+                ? "active"
+                : "not active"
+            ];
+          })()
+            .then(_ => cb(null, _))
+            .catch(() => cb(null, undefined))
+      );
+
+      inputStream
+        .pipe(parser)
+        .pipe(checker)
+        .pipe(transformer)
+        .pipe(process.stdout);
+      // tslint:disable-next-line: no-inferred-empty-object-type
+      await new Promise((res, _) => parser.on("end", res));
+    } catch (e) {
+      this.error(e);
+    }
+  }
+}

--- a/src/commands/profiles/exist.ts
+++ b/src/commands/profiles/exist.ts
@@ -81,9 +81,9 @@ export default class ProfilesExist extends Command {
       );
 
       /**
-       * append to record an entry with the result of check: active if
-       * the fiscalCode is present into the database. As side operation it
-       * return the fiscalCode in upperCase format
+       * it appends to record an entry with the result of check: true if
+       * the fiscalCode is into the database. As side operation it
+       * returns the fiscalCode in upperCase format
        */
       const checker = transform(
         {

--- a/src/commands/profiles/list.ts
+++ b/src/commands/profiles/list.ts
@@ -24,9 +24,9 @@ export default class ProfilesList extends Command {
 
       cli.action.start("Querying profiles...");
       const client = new cosmos.CosmosClient({ endpoint, auth: { key } });
-      const database = await client.database("agid-documentdb-test");
+      const database = client.database("agid-documentdb-test");
       const container = database.container("profiles");
-      const response = await container.items.query(
+      const response = container.items.query(
         "SELECT c.fiscalCode, c._ts FROM c WHERE c.version = 0",
         {
           enableCrossPartitionQuery: true

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -2,4 +2,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 5000
+--timeout 20000

--- a/yarn.lock
+++ b/yarn.lock
@@ -806,6 +806,13 @@ csv-parse@^4.4.1:
   resolved "https://registry.yarnpkg.com/csv-parse/-/csv-parse-4.4.1.tgz#b40df60a3724fdf24ad2856586bf8f1dc7682e54"
   integrity sha512-uFe5phPfmwBXSPWz5GYHeaEc2Oezn2kY5iLIvG1sJjc32Y4GU7T/b/uX5ffZh4CBDWwJQjwAuxrDEdl3Z5Qv+g==
 
+csv-stringify@^5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.3.0.tgz#ff2dfafa6fcccd455ff5039be9c202475aa3bbe0"
+  integrity sha512-VMYPbE8zWz475smwqb9VbX9cj0y4J0PBl59UdcqzLkzXHZZ8dh4Rmbb0ZywsWEtUml4A96Hn7Q5MW9ppVghYzg==
+  dependencies:
+    lodash.get "~4.4.2"
+
 dashdash@^1.12.0:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
@@ -1921,6 +1928,11 @@ lodash.flattendeep@^4.4.0:
   version "4.4.0"
   resolved "https://registry.yarnpkg.com/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz#fb030917f86a3134e5bc9bec0d69e0013ddfedb2"
   integrity sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=
+
+lodash.get@~4.4.2:
+  version "4.4.2"
+  resolved "https://registry.yarnpkg.com/lodash.get/-/lodash.get-4.4.2.tgz#2d177f652fa31e939b4438d5341499dfa3825e99"
+  integrity sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
 
 lodash.template@^4.4.0:
   version "4.4.0"


### PR DESCRIPTION
An utility command to verify if a fiscal code has a profile:

Returns the input CSV with a new column that is true if a profile for that fiscal code exists.

![Schermata 2019-07-10 alle 20 08 56](https://user-images.githubusercontent.com/822471/60993446-c5092c00-a34e-11e9-98d6-3fc3a4cd9327.png)
